### PR TITLE
Platform randomizer.

### DIFF
--- a/SempA2/Assets/Scripts/SpawnPlatforms.cs
+++ b/SempA2/Assets/Scripts/SpawnPlatforms.cs
@@ -12,7 +12,8 @@ public class SpawnPlatforms : MonoBehaviour
     /// <param name="xMinDelta"> Min x distance from previous platform </param>
     /// <param name="xMaxDelta"> Max x distance from previous platform </param>
     public int maxPlatforms = 20;
-    public GameObject platform;
+    public GameObject platform1;
+	public GameObject platform2;
     public float xGroundMin = 1.25f;
     public float xMinDelta = 1.5f;
     public float xMaxDelta = 10f;
@@ -33,13 +34,31 @@ public class SpawnPlatforms : MonoBehaviour
 
     }
 
+//	GameObject random(GameObject platform1, GameObject platform2)
+//	{
+//		GameObject platforms = GameObject.FindGameObjectWithTag ("platform1");
+//		GameObject platforms2 = GameObject.FindGameObjectWithTag ("platform2");
+//		//platforms2 = GameObject.FindGameObjectWithTag ("platform2");
+//		List<GameObject> list = new List<GameObject>();
+//		list.Add (platforms);
+//		list.Add (platforms2);
+//		int index = Random.Range (0, list.Count);
+//		return list[index];
+//
+//
+//	}
+
     void Spawn()
     {
         for (int i = 0; i < maxPlatforms; i++)
         {
 
             Vector2 randomPosition = originPosition + new Vector2(Random.Range(xMinDelta, xMaxDelta), Random.Range(yMinDelta, yMaxDelta));
-            Instantiate(platform, randomPosition, Quaternion.identity);
+			List<GameObject> list = new List<GameObject>();
+			list.Add (platform1);
+			list.Add (platform2);
+			int index = Random.Range (0, list.Count);
+			Instantiate(list[index], randomPosition, Quaternion.identity);
             originPosition = randomPosition;
         }
     }


### PR DESCRIPTION
Changes made- In grassy scene in Unity add two GameObjects from Prefabs, namely platform1 and platform2. Then go to platform Spawner and add the two objects in the respective Platforms(1 and 2).
The Script has been changed to take two GameObjects now. A simple script has been written to add these two platforms into a list and then Randomize the list. This solves the existing issue.
Also check scripts for more info.